### PR TITLE
fix: Modify entrypoint and mounts to fix permission issues for gcloud

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -16,7 +16,13 @@
 
 set -xe
 
+
 sudo chown airflow:airflow airflow
+
+# Workaround for Airflow not being able to read bind mounted gcloud configuration.
+mkdir -p .config/gcloud
+sudo cp gcloud/application_default_credentials.json .config/gcloud/
+sudo chmod +r .config/gcloud/application_default_credentials.json
 
 # That file exists in Composer < 1.19.2 and is responsible for linking name
 # `python` to python3 exec, in Composer >= 1.19.2 name `python` is already

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -60,7 +60,7 @@ def get_image_mounts(
         dags_path: "airflow/dags/",
         env_path / "plugins": "airflow/plugins/",
         env_path / "data": "airflow/data/",
-        gcloud_config_path: ".config/gcloud",
+        gcloud_config_path: "gcloud",
         env_path / "airflow.db": "airflow/airflow.db",
     }
     return [


### PR DESCRIPTION
This PR aims to fix #3 where the Airflow user in the created container is unable to read the gcloud application-default-credentials file.

For safety and to avoid changing UIDs/GIDs, this is done by mounting the gcloud config path to `$AIRFLOW_HOME/gcloud` and locally copying to the location expected by gcloud when looking for credentials.
