### PR TITLE
fix: Modify entrypoint and mounts to fix permission issues for gcloud

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -16,7 +16,13 @@
 
 set -xe
 
+
 sudo chown airflow:airflow airflow
+
+# Workaround for Airflow not being able to read bind mounted gcloud configuration.
+mkdir -p .config/gcloud
+sudo cp gcloud/application_default_credentials.json .config/gcloud/
+sudo chmod +r .config/gcloud/application_default_credentials.json
 
 # That file exists in Composer < 1.19.2 and is responsible for linking name
 # `python` to python3 exec, in Composer >= 1.19.2 name `python` is already

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -60,7 +60,7 @@ def get_image_mounts(
         dags_path: "airflow/dags/",
         env_path / "plugins": "airflow/plugins/",
         env_path / "data": "airflow/data/",
-        gcloud_config_path: ".config/gcloud",
+        gcloud_config_path: "gcloud",
         env_path / "airflow.db": "airflow/airflow.db",
     }
     return [

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -72,7 +72,9 @@ class TestEnvironment:
         exp_err = constants.DOCKER_NOT_AVAILABLE_ERROR.format(
             error="Connection aborted"
         )
-        image_version = f"composer-{composer_version}-airflow-{airflow_version}"
+        image_version = (
+            f"composer-{composer_version}-airflow-{airflow_version}"
+        )
         dags_path = str(pathlib.Path(tmp_path))
         with pytest.raises(
             errors.DockerNotAvailableError,
@@ -347,7 +349,9 @@ class TestEnvironment:
     def test_from_image(
         self, mocked_docker, composer_version, airflow_version, tmp_path
     ):
-        image_version = f"composer-{composer_version}-airflow-{airflow_version}"
+        image_version = (
+            f"composer-{composer_version}-airflow-{airflow_version}"
+        )
         dags_path = str(pathlib.Path(tmp_path))
         env = environment.Environment(
             image_version=image_version,
@@ -954,7 +958,7 @@ def test_get_image_mounts(mocked_mount):
         ),
         mock.call(
             source=gcloud_path,
-            target="/home/airflow/.config/gcloud",
+            target="/home/airflow/gcloud",
             type="bind",
         ),
         mock.call(
@@ -1066,7 +1070,9 @@ class TestEnvironmentConfig:
 
     def test_missing_config(self):
         env_dir = (TEST_DATA_DIR / "missing_composer").resolve()
-        exp_error = f"Configuration file '{env_dir / 'config.json'}' not found."
+        exp_error = (
+            f"Configuration file '{env_dir / 'config.json'}' not found."
+        )
         with pytest.raises(errors.ComposerCliError) as err, working_directory(
             env_dir
         ):
@@ -1123,6 +1129,8 @@ class TestEnvironmentConfig:
         exp_error = constants.INVALID_INT_RANGE_VALUE_ERROR.format(
             param_name=param, value=value, allowed_range=allowed_range
         )
-        with pytest.raises(errors.FailedToParseConfigParamIntRangeError) as err:
+        with pytest.raises(
+            errors.FailedToParseConfigParamIntRangeError
+        ) as err:
             environment.EnvironmentConfig(tmp_path, None)
             assert str(err) == exp_error


### PR DESCRIPTION
This PR aims to fix #3 where the Airflow user in the created container is unable to read the gcloud application-default-credentials file.

For safety and to avoid changing UIDs/GIDs, this is done by mounting the gcloud config path to `$AIRFLOW_HOME/gcloud` and locally copying to the location expected by gcloud when looking for credentials.
