### PR TITLE
Enable usage of artifact-repository in composer-dev template

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,12 @@ and version specifiers.
 
 To apply the changes, [restart your local Airflow environment](#stop-or-restart-a-local-airflow-environment).
 
+### Configure private PyPI repository
+
+To allow installation of PyPI packages from private repositories define PIP_EXTRA_INDEX_URL environment variable that should contain an [alternate package index location](https://mothergeo-py.readthedocs.io/en/latest/development/how-to/alternate-pypi.html#how-to-use-an-alternate-pypi-package-index), eg.
+
+PIP_EXTRA_INDEX_URL=http://pypi.mydomain.com:8080
+
 ### Switch to a different Cloud Composer image
 
 You can use any Cloud Composer 2 image with Composer Local Development CLI
@@ -453,17 +459,3 @@ You can use one of the following solutions:
 - Manually edit the
     `~/Library/Group\ Containers/group.com.docker/settings.json` file and
     add `/opt` to `filesharingDirectories`.
-
-
-### Add private PIP repository
-
-This version is patched to allow additions of a private pip repository per airflow environment.
-
-To enable the installation of the private repository edit your environment variables file within the environment
-`composer/$YOUR_ENVIRONMENT/variables.env`, add the variable:
-
-```sh
-PRIVATE_PIP_INDEX=$URL
-```
-
-the entrypoint will automatically update the pip configuration to add the private repository

--- a/README.md
+++ b/README.md
@@ -454,3 +454,16 @@ You can use one of the following solutions:
     `~/Library/Group\ Containers/group.com.docker/settings.json` file and
     add `/opt` to `filesharingDirectories`.
 
+
+### Add private PIP repository
+
+This version is patched to allow additions of a private pip repository per airflow environment.
+
+To enable the installation of the private repository edit your environment variables file within the environment
+`composer/$YOUR_ENVIRONMENT/variables.env`, add the variable:
+
+```sh
+PRIVATE_PIP_INDEX=$URL
+```
+
+the entrypoint will automatically update the pip configuration to add the private repository

--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -30,10 +30,10 @@ if [ -f /var/local/setup_python_command.sh ]; then
 fi
 
 
-if [ -n "${PRIVATE_PIP_INDEX}" ];then
+if [ -n "${PIP_EXTRA_INDEX_URL}" ];then
   echo "Adding private PyPI repository index: ${PIP_EXTRA_INDEX_URL}"
   pip3 install keyring keyrings.google-artifactregistry-auth
-  pip3 config set global.extra-index-url "${PRIVATE_PIP_INDEX}"
+  pip3 config set global.extra-index-url "${PIP_EXTRA_INDEX_URL}"
 fi
 pip3 install --upgrade -r composer_requirements.txt
 pip3 check

--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -17,6 +17,7 @@
 set -xe
 
 sudo chown airflow:airflow airflow
+sudo chown airflow:airflow .config
 
 mkdir -p ${AIRFLOW__CORE__DAGS_FOLDER}
 mkdir -p ${AIRFLOW__CORE__PLUGINS_FOLDER}
@@ -28,6 +29,15 @@ if [ -f /var/local/setup_python_command.sh ]; then
     /var/local/setup_python_command.sh
 fi
 
+
+pip3 install keyring keyrings.google-artifactregistry-auth
+if [ -z "${PRIVATE_PIP_INDEX}" ] 
+then
+  echo "no private index set"
+else
+  echo "index is set to ${PRIVATE_PIP_INDEX}"
+  pip3 config set global.extra-index-url "${PRIVATE_PIP_INDEX}"
+fi
 pip3 install --upgrade -r composer_requirements.txt
 pip3 check
 

--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -30,12 +30,9 @@ if [ -f /var/local/setup_python_command.sh ]; then
 fi
 
 
-pip3 install keyring keyrings.google-artifactregistry-auth
-if [ -z "${PRIVATE_PIP_INDEX}" ] 
-then
-  echo "no private index set"
-else
-  echo "index is set to ${PRIVATE_PIP_INDEX}"
+if [ -n "${PRIVATE_PIP_INDEX}" ];then
+  echo "Adding private PyPI repository index: ${PIP_EXTRA_INDEX_URL}"
+  pip3 install keyring keyrings.google-artifactregistry-auth
   pip3 config set global.extra-index-url "${PRIVATE_PIP_INDEX}"
 fi
 pip3 install --upgrade -r composer_requirements.txt


### PR DESCRIPTION
This enables `composer-dev` environments to use private pip repositories from GCP `artifact-registry`.
