### PR TITLE
Fixed issue "the triggerer process is not running" by starting it in the Entrypoint of the Dockerfile

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -39,4 +39,5 @@ if ! grep -Fxq "AUTH_ROLE_PUBLIC = 'Admin'" /home/airflow/airflow/webserver_conf
 fi
 
 airflow scheduler &
+airflow triggerer &
 exec airflow webserver


### PR DESCRIPTION
Hello,

I had always had the error message `the triggerer process is not running` when running Deferrable operators in local. I noticed a few months ago that the entrypoint of the Dockerfile was not starting the `triggerer` process [1]

At first I thought this was some kind of known issue but I have not found any information and I realised that when actually executing `airflow triggerer` inside the container in Docker Desktop, the Deferrable operators would work perfectly.

Afterwards, I changed the code of the entrypoint locally from [1] to [2] and it has been already working as expected for around 3 months and I did not detect any issue so far in local, the tasks are deferred succesfully:

![deferrable_local](https://github.com/GoogleCloudPlatform/composer-local-dev/assets/52705438/ac2b43d4-1a82-496d-affb-3559b8b400e8)


[1]:
```
airflow scheduler &
exec airflow webserver
```
[2]:
```
airflow scheduler &
airflow triggerer &
exec airflow webserver
```