### PR TITLE
fix: keep ENV and PYTHONPATH when Composer is started as local user

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -62,9 +62,9 @@ create_user() {
 run_airflow_as_host_user() {
   create_user "${COMPOSER_HOST_USER_NAME}" "${COMPOSER_HOST_USER_ID}"
   echo "Running Airflow as user ${COMPOSER_HOST_USER_NAME}(${COMPOSER_HOST_USER_ID})"
-  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow scheduler &
-  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow triggerer &
-  exec sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow webserver
+  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PYTHONPATH=${PYTHONPATH} PATH=${PATH} airflow scheduler &
+  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PYTHONPATH=${PYTHONPATH} PATH=${PATH} airflow triggerer &
+  exec sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PYTHONPATH=${PYTHONPATH} PATH=${PATH} airflow webserver
 }
 
 run_airflow_as_airflow_user() {

--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -62,9 +62,9 @@ create_user() {
 run_airflow_as_host_user() {
   create_user "${COMPOSER_HOST_USER_NAME}" "${COMPOSER_HOST_USER_ID}"
   echo "Running Airflow as user ${COMPOSER_HOST_USER_NAME}(${COMPOSER_HOST_USER_ID})"
-  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env PATH=${PATH} airflow scheduler &
-  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env PATH=${PATH} airflow triggerer &
-  exec sudo -E -u "${COMPOSER_HOST_USER_NAME}" env PATH=${PATH} airflow webserver
+  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow scheduler &
+  sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow triggerer &
+  exec sudo -E -u "${COMPOSER_HOST_USER_NAME}" env ENV=${ENV} PATH=${PATH} airflow webserver
 }
 
 run_airflow_as_airflow_user() {


### PR DESCRIPTION
Fix #46 
Fix #60

Obviously this solution is not scalable to all the variables that are dropped when doing `sudo -E`. But the `ENV` variable seems more common than most of the others that are being dropped.

If someone has a better idea...