### PR TITLE
feat: Enable supplying and mounting plugins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ composer-dev create \
   --project PROJECT_ID \
   --port WEB_SERVER_PORT \
   --dags-path LOCAL_DAGS_PATH \
+  --plugins-path LOCAL_PLUGINS_PATH \
   LOCAL_ENVIRONMENT_NAME
 ```
 
@@ -137,6 +138,8 @@ Replace:
 - `WEB_SERVER_PORT` with the port that Airflow web server must listen at.
 - `LOCAL_DAGS_PATH` with the path to a local directory where the DAG files are
     located.
+- `LOCAL_PLUGINS_PATH` with the path to a local directory where the plugins
+    files are located.
 - `LOCAL_ENVIRONMENT_NAME` with the name of this local Airflow environment.
 
 Example:
@@ -178,7 +181,8 @@ composer-dev create LOCAL_ENVIRONMENT_NAME \
     --location LOCATION \
     --project PROJECT_ID \
     --port WEB_SERVER_PORT \
-    --dags-path LOCAL_DAGS_PATH
+    --dags-path LOCAL_DAGS_PATH \
+    --plugins-path LOCAL_PLUGINS_PATH
 ```
 
 Replace:
@@ -191,6 +195,8 @@ Replace:
 - `WEB_SERVER_PORT` with a port for the local Airflow web server.
 - `LOCAL_DAGS_PATH` with a path to a local directory where the DAGs are
     located.
+- `LOCAL_PLUGINS_PATH` with a path to a local directory where the plugins are
+    located.
 
 Example:
 
@@ -200,7 +206,8 @@ composer-dev create example-local-environment \
   --location us-central1 \
   --project example-project \
   --port 8081 \
-  --dags-path example_directory/dags
+  --dags-path example_directory/dags \
+  --plugins-path example_directory/plugins
 ```
 
 ## Enable the container user to access mounted files and directories from the host
@@ -253,14 +260,17 @@ composer-dev stop LOCAL_ENVIRONMENT_NAME
 
 ## Add and update DAGs
 
-Dags are stored in the directory that you specified in the `--dags-path`
-parameter when you created your local Airflow environment. By default, this
-directory is `./composer/<local_environment_name>/dags`. You can get the
-directory used by your environment with the
+DAGs and plugins are stored in the directories that you specified in the
+`--dags-path` and `--plugins-path` parameters respectively when you created
+your local Airflow environment. By default, these directories are
+`./composer/<local_environment_name>/dags` and
+`./composer/<local_environment_name>/plugins`.
+
+You can get the directories used by your environment with the
 [`describe` command](#get-a-list-and-status-of-local-airflow-environments).
 
-To add and update DAGs, change files in this directory. You do not need to
-restart your local Airflow environment.
+To add and update DAGs and plugins, change files in these directories. You do
+not need to restart your local Airflow environment for changes to take effect.
 
 ## View local Airflow environment logs
 

--- a/composer_local_dev/cli.py
+++ b/composer_local_dev/cli.py
@@ -239,6 +239,7 @@ def create(
     verbose: bool,
     debug: bool,
     dags_path: Optional[pathlib.Path] = None,
+    plugins_path: Optional[pathlib.Path] = None,
 ):
     """
     Create local Composer development environment.
@@ -292,6 +293,7 @@ def create(
             env_dir_path=env_dir,
             web_server_port=web_server_port,
             dags_path=dags_path,
+            plugins_path=plugins_path,
         )
     else:
         env = composer_environment.Environment(
@@ -301,6 +303,7 @@ def create(
             env_dir_path=env_dir,
             port=web_server_port,
             dags_path=dags_path,
+            plugins_path=plugins_path,
         )
     env.create()
 

--- a/composer_local_dev/constants.py
+++ b/composer_local_dev/constants.py
@@ -70,6 +70,7 @@ Airflow overrides and environment variables are stored in {env_variables_path}.
 You can put your plugins and data to plugins and data directories 
 available at {env_dir}.
 DAGs can be updated at {dags_path} path.
+Plugins can be updated at {plugins_path} path.
 
 To apply changes done to environment config and PyPI dependencies 
 restart environment using following command:
@@ -80,7 +81,8 @@ START_MESSAGE = """
 Started [bold]{env_name}[/] environment.
 
 1. You can put your DAGs in {dags_path}
-2. Access Airflow at http://localhost:{port}
+2. You can put your plugins in {plugins_path}
+3. Access Airflow at http://localhost:{port}
 """
 # TODO: Fill source environment info
 DESCRIBE_ENV_MESSAGE = """
@@ -88,6 +90,7 @@ Composer [bold]{name}[/] environment is in state: {state}.
 {web_url}
 Image version: {image_version}
 Dags directory: {dags_path}.
+Plugins directory: {plugins_path}.
 The environment is using credentials from gcloud located at {gcloud_path}.
 
 This information is based on the data available in the
@@ -102,15 +105,24 @@ IMAGE_TAG_PERMISSION_DENIED_WARN = (
     "Received permission denied when checking "
     "image existence for {image_tag}"
 )
+ADD_DEBUG_ON_ERROR_INFO = "\n\nTo print debug messages please add --debug flag."
 CREATING_DAGS_PATH_WARN = (
     "Dags path '{dags_path}' does not exist. It will be created."
 )
 DAGS_PATH_NOT_PROVIDED_WARN = (
     "No dags directory provided, using default dags directory."
 )
-ADD_DEBUG_ON_ERROR_INFO = "\n\nTo print debug messages please add --debug flag."
 DAGS_PATH_NOT_EXISTS_ERROR = (
     "Dags path does not exist or is not a directory: {dags_path}"
+)
+CREATING_PLUGINS_PATH_WARN = (
+    "Plugins path '{plugins_path}' does not exist. It will be created."
+)
+PLUGINS_PATH_NOT_PROVIDED_WARN = (
+    "No plugins directory provided, using default plugins directory."
+)
+PLUGINS_PATH_NOT_EXISTS_ERROR = (
+    "Plugins path does not exist or is not a directory: {plugins_path}"
 )
 FAILED_TO_GET_DOCKER_PORT_WARN = (
     "Failed to retrieve used port from the Docker daemon, "

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -456,7 +456,6 @@ class Environment:
         self.image_tag = get_docker_image_tag_from_image_version(image_version)
         self.location = location
         self.dags_path = files.resolve_dags_path(dags_path, env_dir_path)
-        # TODO: Implement resolve_plugins_path
         self.plugins_path = files.resolve_plugins_path(plugins_path, env_dir_path)
         self.dag_dir_list_interval = dag_dir_list_interval
         self.port: int = port if port is not None else 8080
@@ -686,7 +685,6 @@ class Environment:
         self.pypi_packages_to_requirements()
         self.environment_vars_to_env_file()
         console.get_console().print(
-            # TODO: Update message template
             constants.CREATE_MESSAGE.format(
                 env_dir=self.env_dir_path,
                 env_name=self.name,
@@ -792,7 +790,6 @@ class Environment:
     def print_start_message(self):
         """Print the start message after the environment is up and ready."""
         console.get_console().print(
-            # TODO: Update message template
             constants.START_MESSAGE.format(
                 env_name=self.name,
                 dags_path=self.dags_path,
@@ -896,7 +893,6 @@ class Environment:
             web_url = ""
         env_status = utils.wrap_status_in_color(env_status)
 
-        # TODO: Update message template
         return constants.DESCRIBE_ENV_MESSAGE.format(
             name=self.name,
             state=env_status,

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -680,9 +680,7 @@ class Environment:
         requirements.txt files.
         """
         assert_image_exists(self.image_version)
-        # TODO: See if this can be created with the same function call
-        files.create_environment_directories(self.env_dir_path, self.dags_path)
-        files.create_environment_directories(self.env_dir_path, self.plugins_path)
+        files.create_environment_directories(self.env_dir_path, self.dags_path, self.plugins_path)
         files.create_empty_file(self.airflow_db, skip_if_exist=False)
         self.write_environment_config_to_config_file()
         self.pypi_packages_to_requirements()

--- a/composer_local_dev/errors.py
+++ b/composer_local_dev/errors.py
@@ -172,6 +172,15 @@ class DAGPathNotExistError(ComposerCliError):
         )
 
 
+class PluginsPathNotExistError(ComposerCliError):
+    """Plugins path does not exist or is not a directory."""
+
+    def __init__(self, plugins_path):
+        super().__init__(
+            constants.PLUGINS_PATH_NOT_EXISTS_ERROR.format(plugins_path=plugins_path)
+        )
+
+
 def catch_exceptions(func=None):
     """
     Catch exceptions and print user friendly message for common issues.

--- a/composer_local_dev/files.py
+++ b/composer_local_dev/files.py
@@ -231,3 +231,10 @@ def assert_dag_path_exists(path: str) -> None:
     if pathlib.Path(path).is_dir():
         return
     raise errors.DAGPathNotExistError(path)
+
+
+def assert_plugins_path_exists(path: str) -> None:
+    """Raise an error if plugins path does not point to existing directory."""
+    if pathlib.Path(path).is_dir():
+        return
+    raise errors.PluginsPathNotExistError(path)

--- a/composer_local_dev/files.py
+++ b/composer_local_dev/files.py
@@ -124,28 +124,35 @@ def resolve_plugins_path(plugins_path: Optional[str], env_dir: pathlib.Path) -> 
     return str(plugins_path.resolve())
 
 
-def create_environment_directories(env_dir: pathlib.Path, dags_path: str):
+def create_environment_directories(env_dir: pathlib.Path, dags_path: str, plugins_path: str):
     """
     Create environment directories (overwriting existing ones).
     Environment directory is a directory which contains configuration files for
     composer local environment and files used by environment such as
     requirements.txt file, dags, data and plugins directories.
     """
-    env_dirs = ("data", "plugins")
+    data_dir = "data"
     LOG.info(
-        "Creating environment directories %s in " "%s environment directory.",
-        env_dirs,
+        "Creating environment directory %s in " "%s environment directory.",
+        data_dir,
         env_dir,
     )
     env_dir.mkdir(exist_ok=True, parents=True)
-    for sub_dir in env_dirs:
-        (env_dir / sub_dir).mkdir(exist_ok=True)
+    (env_dir / data_dir).mkdir(exist_ok=True)
+
     dags_path = pathlib.Path(dags_path)
     if not dags_path.is_dir():
         console.get_console().print(
             constants.CREATING_DAGS_PATH_WARN.format(dags_path=dags_path)
         )
         dags_path.mkdir(parents=True)
+
+    plugins_path = pathlib.Path(plugins_path)
+    if not plugins_path.is_dir():
+        console.get_console().print(
+            constants.CREATING_PLUGINS_PATH_WARN.format(plugins_path=plugins_path)
+        )
+        plugins_path.mkdir(parents=True)
 
 
 def get_available_environments(composer_dir: pathlib.Path):

--- a/composer_local_dev/files.py
+++ b/composer_local_dev/files.py
@@ -107,6 +107,23 @@ def resolve_dags_path(dags_path: Optional[str], env_dir: pathlib.Path) -> str:
     return str(dags_path.resolve())
 
 
+def resolve_plugins_path(plugins_path: Optional[str], env_dir: pathlib.Path) -> str:
+    """
+    Provides and validates path to the plugins directory.
+    If ``plugins_path`` is None, the path is constructed from ``env_dir`` path
+    and ``plugins`` directory.
+    If ``plugins_path`` is not None, but it does not exist, a warning is raised.
+
+    Returns absolute ``plugins_path`` path.
+    """
+    if plugins_path is None:
+        console.get_console().print(constants.PLUGINS_PATH_NOT_PROVIDED_WARN)
+        plugins_path = env_dir / "plugins"
+    else:
+        plugins_path = pathlib.Path(plugins_path)
+    return str(plugins_path.resolve())
+
+
 def create_environment_directories(env_dir: pathlib.Path, dags_path: str):
     """
     Create environment directories (overwriting existing ones).

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -44,12 +44,16 @@ def run_composer_and_assert_exit_code(
 
 
 def assert_environment_directories_exist(
-    env_dir: pathlib.Path, dags_path: Optional[pathlib.Path] = None
+    env_dir: pathlib.Path,
+    dags_path: Optional[pathlib.Path] = None,
+    plugins_path: Optional[pathlib.Path] = None,
 ):
     assert env_dir.exists()
     required_dirs = ["data", "plugins"]
     if dags_path is None:
         required_dirs.append("dags")
+    if plugins_path is None:
+        required_dirs.append("plugins")
     required_files = [
         "airflow.db",
         "config.json",
@@ -91,4 +95,20 @@ def test_create_provide_dags_path(image_exists_mock, tmp_path):
     _, work_dir = run_composer_and_assert_exit_code(cmd, tmp_path)
     env_dir = work_dir / "composer" / env_name
     assert_environment_directories_exist(env_dir, dags_path=dags_path)
+    shutil.rmtree(work_dir)
+
+
+def test_create_provide_plugins_path(image_exists_mock, tmp_path):
+    env_name = "fooenv"
+    plugins_path = tmp_path / "test" / "plugins"
+    cmd = (
+        f"create "
+        f"--from-image-version composer-2.0.15-airflow-2.2.5 "
+        f"--project 123 "
+        f"--plugins-path {plugins_path} "
+        f"{env_name}"
+    )
+    _, work_dir = run_composer_and_assert_exit_code(cmd, tmp_path)
+    env_dir = work_dir / "composer" / env_name
+    assert_environment_directories_exist(env_dir, plugins_path=plugins_path)
     shutil.rmtree(work_dir)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -93,6 +93,17 @@ def test_create_no_dags_path(mocked_env):
     assert exp_dags_path == env_kwargs.get("dags_path")
 
 
+@mock.patch("composer_local_dev.cli.composer_environment.Environment")
+def test_create_no_plugins_path(mocked_env):
+    run_composer_and_assert_exit_code(
+        f"create --project 123 --from-image-version composer-2.0.16-airflow-2.2.5 test",
+        exit_code=0,
+    )
+    _, env_kwargs = mocked_env.call_args
+    exp_plugins_path = None
+    assert exp_plugins_path == env_kwargs.get("plugins_path")
+
+
 class TestCreateCommandProjectId:
     @mock.patch("composer_local_dev.cli.utils.get_project_id", autospec=True)
     @mock.patch(

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -947,6 +947,7 @@ def test_get_environment_variables():
 def test_get_image_mounts(mocked_mount):
     path = pathlib.Path("path/dir")
     dags_path = "path/to/dags"
+    plugins_path = "path/to/plugins"
     gcloud_path = "config/path"
     requirements = path / "requirements.txt"
     airflow_db_path = path / "airflow.db"
@@ -957,10 +958,12 @@ def test_get_image_mounts(mocked_mount):
             type="bind",
         ),
         mock.call(
-            source=dags_path, target="/home/airflow/gcs/dags/", type="bind"
+            source=dags_path,
+            target="/home/airflow/gcs/dags/",
+            type="bind",
         ),
         mock.call(
-            source=str(path / "plugins"),
+            source=plugins_path,
             target="/home/airflow/gcs/plugins/",
             type="bind",
         ),
@@ -981,7 +984,7 @@ def test_get_image_mounts(mocked_mount):
         ),
     ]
     actual_mounts = environment.get_image_mounts(
-        path, dags_path, gcloud_path, requirements
+        path, dags_path, plugins_path, gcloud_path, requirements
     )
     assert len(expected_mounts) == len(actual_mounts)
     mocked_mount.assert_has_calls(expected_mounts)


### PR DESCRIPTION
This PR adds a new `plugins-path` parameter to `composer-dev create`, which enables users to supply their own plugins path which can be mounted in the Docker container. This supports use cases where the plugins path is not in the expected default location, and enables changing plugins files without restarting the local Composer environment.

The implementation of `plugins-path` copies the existing implementation of `dags-path`. The code could probably be consolidated a bit better. This change hasn't been tested yet, although tests have been added and modified. I would appreciate early feedback in the meanwhile.