### PR TITLE
Avoid SyntaxWarning by making IMAGE_VERSION_PATTERN a raw string

### DIFF
--- a/composer_local_dev/constants.py
+++ b/composer_local_dev/constants.py
@@ -33,7 +33,7 @@ class ContainerStatus(str, enum.Enum):
 COMPOSER_VERSIONING_DOCS_LINK = "https://cloud.google.com/composer/docs/concepts/versioning/composer-versions"
 COMPOSER_FAQ_MOUNTING_LINK = "https://cloud.google.com/composer/docs/composer-2/run-local-airflow-environments#troubleshooting-homebrew"
 IMAGE_VERSION_PATTERN = (
-    "composer-([1-9]+\.[0-9]+\.[0-9]+)-airflow-([1-9]+[\.|-][0-9]+[\.|-][0-9]+)"
+    r"composer-([1-9]+\.[0-9]+\.[0-9]+)-airflow-([1-9]+[\.|-][0-9]+[\.|-][0-9]+)"
 )
 ARTIFACT_REGISTRY_IMAGE_URL = (
     "projects/cloud-airflow-releaser/"


### PR DESCRIPTION
This change avoids the following warning:

	composer-local-dev/composer_local_dev/constants.py:36: SyntaxWarning: invalid escape sequence '\.'
	  "composer-([1-9]+\.[0-9]+\.[0-9]+)-airflow-([1-9]+[\.|-][0-9]+[\.|-][0-9]+)"