### PR TITLE
Update docker pakckage from v6 to v7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dependencies = [
     "google-cloud-orchestration-airflow>=1.2.0",
     "google-cloud-artifact-registry>=1.2.0",
     "rich_click==1.4.0",
-    "docker==6.*",
+    "docker==7.*",
 ]
 extras = {
     "tests": ["pytest", "nox", "coverage"],


### PR DESCRIPTION
This makes the tool work with newer Docker Desktop versions (2.34+).