### PR TITLE
Change `airflow db init` to `airflow db migrate` in entrypoint script

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -33,7 +33,7 @@ init_airflow() {
   pip3 install --upgrade -r composer_requirements.txt
   pip3 check
 
-  airflow db init
+  airflow db migrate
 
   # Allow non-authenticated access to UI for Airflow 2.*
   if ! grep -Fxq "AUTH_ROLE_PUBLIC = 'Admin'" /home/airflow/airflow/webserver_config.py; then


### PR DESCRIPTION
## What I changed

Changed `airflow db init` to `airflow db migrate` in entrypoint script.


## Why?

[`airflow db migrate`](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#migrate) is recommended for database setup in newer versions of Airflow.

see: https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#initialize-the-database


On the other hand, [`airflow db init`](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#migrate) is undocumented in the latest documentation.


running `composer-dev start` shows a warning for using `airflow db init`:

```
$ composer-dev  --version
composer-dev, version 0.9.2

$ composer-dev create  --from-image-version composer-2.9.11-airflow-2.9.3 composer-local
$ composer-dev start composer-local

...
2024-12-05T12:14:03.450033053Z /opt/python3.11/lib/python3.11/site-packages/airflow/cli/commands/db_command.py:48 DeprecationWarning: `db init` is deprecated.
Use `db migrate` instead to migrate the db and/or airflow connections create-default-connections to create the default connections
```

## Additional Information

As a side effect, in my environment, the sqlite lock issue like #63 during restart was resolved.

Although the exact reason is unclear, it seems that airflow db migrate handles retries more appropriately during lock situations.