### PR TITLE
Add support for Airflow 2.6

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -34,7 +34,14 @@ init_airflow() {
   $run_as_user pip3 install --upgrade -r composer_requirements.txt
   $run_as_user pip3 check
 
-  $run_as_user airflow db migrate
+  airflow_version=$(${run_as_user} airflow version | grep -o "^[0-9\.]*")
+  version_array=($(echo "$airflow_version" | tr '.' ' '))
+
+  if [ "${version_array[0]}" -eq "2" ] && [ "${version_array[1]}" -lt "7" ]; then
+    $run_as_user airflow db init
+  else
+    $run_as_user airflow db migrate
+  fi
 
   # Allow non-authenticated access to UI for Airflow 2.*
   if ! grep -Fxq "AUTH_ROLE_PUBLIC = 'Admin'" /home/airflow/airflow/webserver_config.py; then

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -49,7 +49,7 @@ def get_env_var(name: str) -> str:
 
 @pytest.fixture(scope="session")
 def composer_image_version_older() -> str:
-    return "composer-2.6.5-airflow-2.7.3"
+    return "composer-2.6.5-airflow-2.6.3"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Why?
As mentioned in #86, users running a Composer image with an Airflow version below 2.7 are unable to run `composer-dev start`.

# What?
This commit adds support for Airflow `>2.0,<2.7`, which uses `airflow db init` rather than `airflow db migrate`.

# How was this tested?
We are unable to run the integration test suite locally, and have resorted to manual validation. However, the e2e test suite should be configured to run the tests.