### PR TITLE
relax google-auth constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ release_status = (
 dependencies = [
     "click>=7.0,<8.2",
     "docker>=7.0.0",
-    "google-auth==2.27.*",
+    "google-auth>=2.27.0",
     "google-cloud-orchestration-airflow>=1.2.0",
     "google-cloud-artifact-registry>=1.2.0",
     "rich_click==1.4.0",


### PR DESCRIPTION
🔧 Fix dependency conflict between `composer-dev` and `apache-airflow-providers-google`

🧩 Summary of Changes
- Pins `google-auth` to `>=2.27.0` to relax `composer-dev`'s tight constraints.

🚧 Why?
`composer-dev==0.10.0` requires `google-auth<2.28`, while `apache-airflow-providers-google==15.1.0` needs `>=2.29.0`, creating a dependency conflict.