### PR TITLE
use since parameter to only detect airflow readiness from new logs

### DIFF
--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -943,7 +943,7 @@ class Environment:
         ):
             self.assert_container_is_active(self.container_name)
             for line in self.get_container(self.container_name).logs(
-                stream=True, timestamps=True
+                stream=True, timestamps=True, since=start_time
             ):
                 line = line.decode("utf-8").strip()
                 console.get_console().print(line)


### PR DESCRIPTION
<!--
 Copyright 2022 Google LLC

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

Fix log persistence issue when restarting existing containers. When stopping a composer instance and starting a new one with `composer-dev start`, logs from previous container instances would be used. This causes the "readiness" check to trigger too early because it uses the first instance of `"Searching for files"` in the logs.  If we use `since=start_time`, it will only use new logs to check readiness/stream them to the console.

- All contributions have to be merged to the `development` branch, please
make sure you set it as the target of this PR. ✅ 
- Confirm you ran `pytest tests` and all the unit tests are green. ✅ 
