### PR TITLE
fix: add missing --plugins-path option to create command

### DIFF
--- a/composer_local_dev/cli.py
+++ b/composer_local_dev/cli.py
@@ -226,6 +226,13 @@ option_location = click.option(
     type=click.Path(file_okay=False),
 )
 @click.option(
+    "--plugins-path",
+    help="Path to plugins folder. If it does not exist, it will be created.",
+    show_default="'plugins' directory in the environment directory",
+    metavar="PATH",
+    type=click.Path(file_okay=False),
+)
+@click.option(
     "--database-engine",
     "--database",
     help="Database engine for airflow metadata.",


### PR DESCRIPTION
## Summary
The `--plugins-path` option was listed in `OPTION_GROUPS` and expected as a parameter in the `create()` function, but was never defined as a `@click.option` decorator.

## Problem
Users trying to use `--plugins-path` would get an "unrecognized option" error, even though the option was documented in the help text groupings.

## Solution
Added the missing `@click.option` decorator for `--plugins-path` to the `create` command.

## Testing
- Verified `composer-dev create --help` now shows `--plugins-path` in the "Environment options" group
- Confirmed the option is properly passed to the `create()` function
- All 155 unit tests pass ✅


<!--
 Copyright 2022 Google LLC

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
# New PR

Thank you for contributing!

- All contributions have to be merged to the `development` branch, please
make sure you set it as the target of this PR.
- Confirm you ran `pytest tests` and all the unit tests are green.
