### PR TITLE
fix: improve airflow version parsing

### DIFF
--- a/composer_local_dev/docker_files/entrypoint.sh
+++ b/composer_local_dev/docker_files/entrypoint.sh
@@ -21,7 +21,7 @@ FAST_API_DIR=/opt/python3.11/lib/python3.11/site-packages/airflow/api_fastapi/
 run_as_user=/home/airflow/run_as_user.sh
 
 get_airflow_version() {
-  airflow_version=$(${run_as_user} airflow version | grep -o "^[0-9\.]*")
+  airflow_version=$(${run_as_user} airflow version 2>/dev/null | grep -oE '[0-9]\.[0-9]+\.[0-9]+' | head -1)
   original_ifs="$IFS"
   IFS='.'
   set -- $airflow_version


### PR DESCRIPTION
The original grep expression is incorrectly parsing airflow version when SecretBackend is enabled.
SecretBackend prints out additional information that are incorrectly recognised by grep expression as airflow version.

```
2026-02-12T10:26:29.730191461Z ++ airflow_version='2026
2026-02-12T10:26:29.730215878Z 3.1.0'
2026-02-12T10:26:29.730218170Z ++ original_ifs='
2026-02-12T10:26:29.730219670Z '
2026-02-12T10:26:29.730365380Z ++ IFS=.
2026-02-12T10:26:29.730542716Z ++ set -- '2026
2026-02-12T10:26:29.730548341Z 3' 1 0
2026-02-12T10:26:29.730637343Z ++ major='2026
2026-02-12T10:26:29.730641260Z 3'
2026-02-12T10:26:29.730642426Z ++ minor=1
2026-02-12T10:26:29.730643343Z ++ patch=0
2026-02-12T10:26:29.730644176Z ++ IFS='
2026-02-12T10:26:29.730645093Z '
2026-02-12T10:26:29.730645926Z ++ echo '2026
2026-02-12T10:26:29.730646718Z 3' 1 0
2026-02-12T10:26:29.733226133Z + major=2026
2026-02-12T10:26:29.733235050Z + init_airflow
```


pytest passed
the fix working for composer-3-airflow-3.1.0-build.8

<!--
 Copyright 2022 Google LLC

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
# New PR

Thank you for contributing!

- All contributions have to be merged to the `development` branch, please
make sure you set it as the target of this PR.
- Confirm you ran `pytest tests` and all the unit tests are green.
