### PR TITLE
fix: exclude Postgres-specific vars from Airflow container environment

### DIFF
--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -1132,10 +1132,33 @@ class Environment:
             self.ensure_container_is_attached_to_network(db_container)
             LOG.info(f"Database started!")
 
-        container = self.start_container(
-            self.container_name, assert_not_running
-        )
+        # Attach to network before starting to avoid DNS resolution race:
+        # entrypoint runs "airflow db migrate" immediately on container start,
+        # so the container must already be on the Docker network at that point.
+        container = self.get_or_create_container(self.container_name)
+        if (
+            assert_not_running
+            and container.status == constants.ContainerStatus.RUNNING
+        ):
+            raise errors.EnvironmentAlreadyRunningError(self.name) from None
         self.ensure_container_is_attached_to_network(container)
+        try:
+            container.start()
+        except docker.errors.APIError as err:
+            logging.debug(
+                "Starting environment failed with Docker API error.",
+                exc_info=True,
+            )
+            if (
+                err.status_code == constants.SERVER_ERROR_CODE
+                and "port is already allocated" in str(err)
+            ):
+                container.remove()
+                raise errors.ComposerCliError(
+                    constants.PORT_IN_USE_ERROR.format(port=self.port)
+                )
+            error = f"Environment ({self.container_name}) failed to start with an error: {err}"
+            raise errors.EnvironmentStartError(error) from None
         self.wait_for_start()
         self.print_start_message()
 

--- a/composer_local_dev/environment.py
+++ b/composer_local_dev/environment.py
@@ -694,7 +694,7 @@ class Environment:
             ),
             "GCP_PROJECT": self.project_id,
             "GOOGLE_CLOUD_PROJECT": self.project_id,
-            **default_db_variables,
+            **{k: v for k, v in default_db_variables.items() if k.startswith("AIRFLOW__")},
             **self.get_environment_variables_for_image_version(),
         }
 
@@ -1132,33 +1132,10 @@ class Environment:
             self.ensure_container_is_attached_to_network(db_container)
             LOG.info(f"Database started!")
 
-        # Attach to network before starting to avoid DNS resolution race:
-        # entrypoint runs "airflow db migrate" immediately on container start,
-        # so the container must already be on the Docker network at that point.
-        container = self.get_or_create_container(self.container_name)
-        if (
-            assert_not_running
-            and container.status == constants.ContainerStatus.RUNNING
-        ):
-            raise errors.EnvironmentAlreadyRunningError(self.name) from None
+        container = self.start_container(
+            self.container_name, assert_not_running
+        )
         self.ensure_container_is_attached_to_network(container)
-        try:
-            container.start()
-        except docker.errors.APIError as err:
-            logging.debug(
-                "Starting environment failed with Docker API error.",
-                exc_info=True,
-            )
-            if (
-                err.status_code == constants.SERVER_ERROR_CODE
-                and "port is already allocated" in str(err)
-            ):
-                container.remove()
-                raise errors.ComposerCliError(
-                    constants.PORT_IN_USE_ERROR.format(port=self.port)
-                )
-            error = f"Environment ({self.container_name}) failed to start with an error: {err}"
-            raise errors.EnvironmentStartError(error) from None
         self.wait_for_start()
         self.print_start_message()
 


### PR DESCRIPTION
`PGDATA` was included in the Airflow container environment via `**default_db_variables` spread in `get_default_environment_variables()`. The Airflow entrypoint runs `sudo chmod -R o+xrw $PGDATA` when `$PGDATA` is set, which corrupts the Postgres data directory permissions. Postgres requires strict permissions (`0700`/`0750`) and refuses to start after the chmod, causing its hostname to disappear from Docker DNS -- which surfaced as a misleading DNS resolution error.

Filter `default_db_variables` to only pass `AIRFLOW__*`-prefixed keys to the Airflow container. Postgres-specific vars (`PGDATA`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) are not needed by Airflow.

Resolves #142.

<!--
 Copyright 2022 Google LLC

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
# New PR

Thank you for contributing!

- (*CONFIRMED*) All contributions have to be merged to the `development` branch, please
make sure you set it as the target of this PR.
- Confirm you ran `pytest tests` and all the unit tests are green -- Tests are failing locally, but I found out that this is because of other reasons. I created a PR #144 to fix tests.