### PR TITLE
fix: correct integration test assertions for postgresql create

### DIFF
--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -49,13 +49,13 @@ def assert_environment_directories_exist(
     plugins_path: Optional[pathlib.Path] = None,
 ):
     assert env_dir.exists()
-    required_dirs = ["data", "plugins"]
+    required_dirs = ["data", "postgresql_data"]
     if dags_path is None:
         required_dirs.append("dags")
     if plugins_path is None:
         required_dirs.append("plugins")
     required_files = [
-        "airflow.db",
+        ".keep",
         "config.json",
         "variables.env",
         "requirements.txt",


### PR DESCRIPTION
Fix two problems in `assert_environment_directories_exist`:
- "plugins" was in the initial required_dirs list AND conditionally appended, causing it to appear twice when plugins_path is not provided
- "airflow.db" was expected but postgresql engine creates ".keep" (sqlite3 creates airflow.db); all three tests use the postgresql default
- "postgresql_data" directory was not expected but is created by create_database_files() for postgresql engine

<!--
 Copyright 2022 Google LLC

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
# New PR

Thank you for contributing!

- (*CONFIRMED*) All contributions have to be merged to the `development` branch, please
make sure you set it as the target of this PR.
- (*CONFIRMED*) Confirm you ran `pytest tests` and all the unit tests are green.